### PR TITLE
Make Scheduler a Modifiable Parameter

### DIFF
--- a/run_rep_learner.py
+++ b/run_rep_learner.py
@@ -72,7 +72,7 @@ def run(env_id, seed, algo, n_envs, timesteps, train_from_expert,
     model = algo(env, log_dir=log_dir, **algo_params)
 
     # setup model
-    model.learn(data)
+    model.learn(data, pretrain_epochs)
 
     env.close()
 

--- a/test_base_algos.py
+++ b/test_base_algos.py
@@ -2,6 +2,8 @@ import warnings
 
 # numpy warnings because of tensorflow
 warnings.filterwarnings("ignore", category=FutureWarning)
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+warnings.filterwarnings("ignore", category=PendingDeprecationWarning)
 from tensorflow.python.util import deprecation
 deprecation._PRINT_DEPRECATION_WARNINGS = False
 


### PR DESCRIPTION
A small PR to make the `scheduler` used by `representation_learner` controllable as a parameter. This also allows us to move `pretrain_epochs` from being something defined upon initialization into something that can be passed in as a parameter to the `learn` method, where (at least in my eyes) it more naturally belongs. 