### PR TITLE
Code Optimization: Reduce Logging

### DIFF
--- a/src/il_representations/algos/representation_learner.py
+++ b/src/il_representations/algos/representation_learner.py
@@ -369,7 +369,7 @@ class RepresentationLearner(BaseEnvironmentLearner):
                 loss = self.loss_calculator(decoded_contexts, decoded_targets, encoded_contexts)
                 if batches_trained % self.calc_log_interval == 0:
                     loss_item = loss.item()
-                    assert not np.isnan(loss_item), "Loss is not NAN"
+                    assert not np.isnan(loss_item), "Loss is NaN"
                 self.optimizer.zero_grad()
                 loss.backward()
                 self.optimizer.step()


### PR DESCRIPTION
There seems to be good evidence that reducing the frequency with which we make .item() calls and add that to a logger can dramatically reduce training time (on the order of 30% if we reduce to adding information to the log on every 10th batch rather than every batch). 

200 batches, save info every batch:
> Total train time: 3:44 
learn() method total: 211s
item() calls: 73.8s

200 batches, save info every 10 batches:
> Total train time: 2:40
learn() method total: 145s
item() calls: 7.9s



Code changes involved: 
- Add a parameter for how often to calculate information to add to the log 
- Gate existing logging code under a mod check for batches_trained being on the information calculation interval 
- Remove one usage of `loss_meter.update(loss_item)` that seemed to be a duplicate call in the original code 